### PR TITLE
BANDWITH: Add DYNAMIC option to be able to autoselect default interface

### DIFF
--- a/doc/yabar.1
+++ b/doc/yabar.1
@@ -461,7 +461,10 @@ Network bandwidth: It checks out the total transmitted and received bytes in the
 
 .nf
 exec: "YABAR\_BANDWIDTH";
-internal\-option1: "enp2s0"; #i.e. Replace NAME with your corresponding name
+internal\-option1: ""; #Auto mode
+internal\-option1: "enp2s0"; #By default if you put nothing, yabar will choose the most appropriate
+                              interface for you (based on your default route). But you can override
+                              that by specifying yourself the name of the interface to pick
 internal\-option2: " "; #Two Strings (usually 2 font icons) to be injected before down/up values
 interval: 2;
 


### PR DESCRIPTION
I often switch between Ethernet and wifi, so it is always a pain to manually change the config file when It happens.

I added an special interface name "DYNAMIC" that when is use will force yabar to take the interface of the default route of your computer.
It fallback to loopback interface if none is found.