### PR TITLE
add disk usage block

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,4 +1,4 @@
-# yabar contributors (as of 2017-01-06)
+# yabar contributors (as of 2017-01-12)
 Andrei Barbu <andrei@0xab.com>
 Bernd Busse <bernd@busse-net.de>
 Fabio Iacovino <fabio.iacovino99@gmail.com>
@@ -9,8 +9,11 @@ George Badawi <geommer@gmail.com>
 Ian Whitlock <iwhitlock@vmware.com>
 Jack Henschel <henschjk@iis.fraunhofer.de>
 Jack Henschel <jh@openmailbox.org>
+Jack <twc-thewheelychecker@hotmail.com>
 kj <kamijo@ninja.co.jp>
 Linden Krouse <ztaticnull@gmail.com>
+losynix <losynix@openmailbox.org>
 NBonaparte <98007b33@opayq.com>
 ~P <huffstler@users.noreply.github.com>
+Romain GERARD <r.gerard@criteo.com>
 Sébastien Viande <sviande@gmail.com>

--- a/doc/yabar.1
+++ b/doc/yabar.1
@@ -535,6 +535,26 @@ internal-option2 : "Master;0"; # Mixer index (separated by a semicolon)
 internal-option3 : " ;"; # characters to display when sound is on or off (separated by a semicolon)
 internal-suffix: "%";
 
+.fi
+.RE
+.IP \(bu 2
+Disk space usage: Display used/total space (e.g. 84G/320G) for one or multiple file systems. Example:
+.PP
+.RS
+
+.nf
+exec: "YABAR_DISKSPACE";
+align: "right";
+interval: 10;
+internal\-prefix: " ";
+internal\-option1: "/dev/sda";
+
+internal-option1 is used to match the first column of \fB\fC/etc/mtab\fR so there are multiple cases:
+	"/dev/sda1"           first partition of device sda
+	"/dev/sdb"            all mounted partitions of device sdb
+	"/dev/mapper/vgc-"    all mounted logical volumes of volume group vgc
+	"/dev"                all mounted partitions / logical volumes
+
 .SH LICENSE
 .PP
 Yabar is licensed under the MIT license. For more info check out the file \fB\fCLICENSE\fR\&.

--- a/examples/example.config
+++ b/examples/example.config
@@ -4,7 +4,7 @@
 bar-list = ["topbar"];
 topbar:{
 	font: "Droid Sans, FontAwesome Bold 9";
-    block-list: ["ya_ws", "ya_title", "ya_date", "ya_volume", "ya_uptime", "ya_cpu", "ya_thermal", "ya_brightness", "ya_bw", "ya_mem", "ya_disk", "ya_bat"];
+    block-list: ["ya_diskspace", "ya_ws", "ya_title", "ya_date", "ya_volume", "ya_uptime", "ya_cpu", "ya_thermal", "ya_brightness", "ya_bw", "ya_mem", "ya_disk", "ya_bat"];
 	position: "top";
 	gap-horizontal: 10;
 	gap-vertical: 10;
@@ -140,6 +140,21 @@ topbar:{
 		background-color-rgb:0x49708A;
 		underline-color-rgb:0xECD078;
 		#internal-spacing: true;
+	}
+	ya_diskspace:{
+		exec: "YABAR_DISKSPACE";
+		align: "left";
+		fixed-size: 120;
+		interval: 10;
+		internal-prefix: " ";
+		# examples for this option:
+		# "/dev/sda1"           first partition of device sda
+		# "/dev/sdb"            all mounted partitions of device sdb
+		# "/dev/mapper/vgc-"    all mounted logical volumes of volume group vgc
+		# "/dev"                all mounted partitions / logical volumes
+		internal-option1: "/dev/sda";
+		background-color-rgb:0x49708A;
+		underline-color-rgb:0xECD078;
 	}
     # example for an external block
 	title: {

--- a/include/yabar.h
+++ b/include/yabar.h
@@ -118,9 +118,9 @@ enum {
 
 
 #ifdef YA_INTERNAL_EWMH
-#define YA_INTERNAL_LEN 14
+#define YA_INTERNAL_LEN 15
 #else
-#define YA_INTERNAL_LEN 12
+#define YA_INTERNAL_LEN 13
 #endif
 enum {
 	YA_INT_DATE = 0,
@@ -135,6 +135,7 @@ enum {
 	YA_INT_NETWORK,
 	YA_INT_BATTERY,
 	YA_INT_VOLUME,
+	YA_INT_DISKSPACE,
 	YA_INT_TITLE,
 	YA_INT_WORKSPACE
 };

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -680,7 +680,10 @@ ya_volume_error:
 	pthread_exit(NULL);
 }
 
+/* -- Disk usage block -- */
 static const char const symbols[5] = {0, 'K', 'M', 'G', 'T'};
+/* bytes to human-readable str: convert an amount of bytes to a string with the
+   corresponding suffix. e.g. "123456789" -> "117.7M" (bytes) */
 static int btohstr(char *str, uint64_t bytes)
 {
 	double size = bytes;
@@ -702,6 +705,8 @@ void ya_int_diskspace(ya_block_t *blk) {
 	int8_t mntpntcount = -1;
 	FILE *mntentfile = setmntent("/etc/mtab", "r");;
 	struct mntent *m;
+	/* read /etc/mtab to get all mountpoints where the underlying device or
+	   volume group matches the internal-option1 */
 	while ( (m = getmntent(mntentfile)) != NULL ) {
 		if (strncmp(m->mnt_fsname, blk->internal->option[0],
 					strlen(blk->internal->option[0])) == 0) {
@@ -727,6 +732,7 @@ void ya_int_diskspace(ya_block_t *blk) {
 	while (1) {
 		free = 0;
 		total = 0;
+        /* get and sum used / total space of every mountpoints */
 		for( int i = 0; i <= mntpntcount; i++) {
 			if ( statvfs(mountpoints[i], &stat) != -1 ) {
 				free += (uint64_t)(stat.f_bfree * stat.f_bsize);

--- a/src/intern_blks/ya_intern.c
+++ b/src/intern_blks/ya_intern.c
@@ -20,6 +20,7 @@ void ya_int_diskio(ya_block_t *blk);
 void ya_int_network(ya_block_t *blk);
 void ya_int_battery(ya_block_t *blk);
 void ya_int_volume(ya_block_t *blk);
+void ya_int_diskspace(ya_block_t *blk);
 
 struct reserved_blk ya_reserved_blks[YA_INTERNAL_LEN] = {
 	{"YABAR_DATE", ya_int_date},
@@ -34,6 +35,7 @@ struct reserved_blk ya_reserved_blks[YA_INTERNAL_LEN] = {
 	{"YABAR_NETWORK", ya_int_network},
 	{"YABAR_BATTERY", ya_int_battery},
 	{"YABAR_VOLUME", ya_int_volume},
+	{"YABAR_DISKSPACE", ya_int_diskspace},
 #ifdef YA_INTERNAL_EWMH
 	{"YABAR_TITLE", NULL},
 	{"YABAR_WORKSPACE", NULL}
@@ -676,6 +678,71 @@ ya_volume_error:
 	ya_draw_pango_text(blk);
 	pthread_detach(blk->thread);
 	pthread_exit(NULL);
+}
+
+static const char const symbols[5] = {0, 'K', 'M', 'G', 'T'};
+static int btohstr(char *str, uint64_t bytes)
+{
+	double size = bytes;
+	int exp = 0;
+	while (size >= 1024 && exp < 4) {
+		size /= 1024;
+		exp++;
+	}
+	return sprintf(str, "%.1f%c", size, symbols[exp]);
+}
+#include <mntent.h>
+#include <sys/statvfs.h>
+#define MAX_MOUNTPOINTS 15
+void ya_int_diskspace(ya_block_t *blk) {
+	char *startstr = blk->buf;
+	size_t prflen = 0, suflen = 0;
+	ya_setup_prefix_suffix(blk, &prflen, &suflen, &startstr);
+	char *mountpoints[MAX_MOUNTPOINTS];
+	int8_t mntpntcount = -1;
+	FILE *mntentfile = setmntent("/etc/mtab", "r");;
+	struct mntent *m;
+	while ( (m = getmntent(mntentfile)) != NULL ) {
+		if (strncmp(m->mnt_fsname, blk->internal->option[0],
+					strlen(blk->internal->option[0])) == 0) {
+			mountpoints[++mntpntcount] = strdup(m->mnt_dir);
+		}
+		if ( mntpntcount == (MAX_MOUNTPOINTS - 1)) {
+			fprintf(stderr, "max mount points reached");
+			break;
+		}
+	}
+	endmntent(mntentfile);
+	if ( mntpntcount == -1 ) {
+		fprintf(stderr, "no mount points found for prefix \"%s\"\n",
+				blk->internal->option[0]);
+		strncpy(blk->buf, "BLOCK ERROR!", strlen("BLOCK ERROR!"));
+		ya_draw_pango_text(blk);
+		pthread_detach(blk->thread);
+		pthread_exit(NULL);
+	}
+	uint64_t free, total;
+	struct statvfs stat;
+	char sizebuf[7];
+	while (1) {
+		free = 0;
+		total = 0;
+		for( int i = 0; i <= mntpntcount; i++) {
+			if ( statvfs(mountpoints[i], &stat) != -1 ) {
+				free += (uint64_t)(stat.f_bfree * stat.f_bsize);
+				total += (uint64_t)(stat.f_blocks * stat.f_bsize);
+			}
+		}
+		btohstr(sizebuf, total - free);
+		sprintf(startstr, sizebuf);
+		strcat(startstr, "/");
+		btohstr(sizebuf, total);
+		strcat(startstr, sizebuf);
+		if(suflen)
+			strcat(blk->buf, blk->internal->suffix);
+		ya_draw_pango_text(blk);
+		sleep(blk->sleep);
+	}
 }
 
 #define _GNU_SOURCE


### PR DESCRIPTION
New block that displays "used/total" space. Example:
	
```
ya_diskspace:{
		exec: "YABAR_DISKSPACE";
		internal-prefix: " ";
		# examples for this option:
		# "/dev/sda1"           first partition of device sda
		# "/dev/sdb"            all mounted partitions of device sdb
		# "/dev/mapper/vgc-"    all mounted logical volumes of volume group vgc
		# "/dev"                all mounted partitions / logical volumes
		internal-option1: "/dev/sda";
}
```
